### PR TITLE
Add CODE_OF_CONDUCT.md and link it in README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in TourEase a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity, level of experience, nationality, personal appearance, race, religion, or sexual identity.
+
+## Our Standards
+Examples of behavior that contributes to a positive environment:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Unacceptable behavior includes:
+- Harassment, intimidation, or discriminatory comments
+- Publishing private information without consent
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+Project maintainers are responsible for clarifying standards of acceptable behavior and taking appropriate action in response to any instances of unacceptable behavior.
+
+## Scope
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+Maintainers who do not follow or enforce the Code of Conduct may be removed from the project community.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - Travel enthusiasts who provide valuable feedback
 
 ---
+
+## Code of Conduct
+Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for details on expected behavior and reporting guidelines.
+
 ## 👩‍💻 Author
 
 **Suhani**


### PR DESCRIPTION
This PR adds a CODE_OF_CONDUCT.md file to TourEase to:

- Define expected behavior for all contributors
- Provide reporting guidelines
- Ensure a safe, welcoming, and inclusive environment

The README is updated with a link to the Code of Conduct.
