### PR TITLE
Fix README: correct dev command and setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Our mission is to make travel **personalized**, **safe**, and **immersive** for 
 
    # In a new terminal, start frontend
    cd frontend
-   npm start
+   npm run dev
    
 
 5. **Access the application**


### PR DESCRIPTION
Fixed README instructions.
Updated run command from `npm start` to `npm run dev`
to match Vite configuration.
