### PR TITLE
Add Responsive Navigation Menu for Mobile Devices

### DIFF
--- a/frontend/src/components/Navigation.css
+++ b/frontend/src/components/Navigation.css
@@ -1,0 +1,32 @@
+/* Mobile Navigation Enhancements */
+
+/* Prevent body scroll when mobile menu is open */
+.mobile-menu-open {
+  overflow: hidden;
+}
+
+/* Ensure proper touch targets for mobile */
+@media (max-width: 767px) {
+  .touch-target {
+    min-height: 44px;
+    min-width: 44px;
+  }
+  
+  /* Improve tap highlighting */
+  .mobile-nav-link {
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0.1);
+    tap-highlight-color: rgba(0, 0, 0, 0.1);
+  }
+  
+  /* Smooth menu animation */
+  .mobile-menu-container {
+    transition: max-height 0.3s ease-in-out, opacity 0.3s ease-in-out;
+  }
+}
+
+/* Focus styles for accessibility */
+.nav-button:focus-visible,
+.nav-link:focus-visible {
+  outline: 2px solid #0ea5e9;
+  outline-offset: 2px;
+}

--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Menu, X, Heart } from 'lucide-react';
 import { useFavorites } from '../hooks/useFavorites';
+import './Navigation.css';
 
 export default function Navigation() {
     const [isOpen, setIsOpen] = useState(false);
@@ -22,7 +23,39 @@ export default function Navigation() {
     const handleLogoClick = () => {
         navigate("/");
         window.scrollTo(0, 0);
+        setIsOpen(false); // Close mobile menu when navigating
     };
+
+    // Close mobile menu on route change
+    useEffect(() => {
+        setIsOpen(false);
+    }, [location.pathname]);
+
+    // Close mobile menu on window resize (when switching to desktop)
+    useEffect(() => {
+        const handleResize = () => {
+            if (window.innerWidth >= 768) {
+                setIsOpen(false);
+            }
+        };
+
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    // Prevent body scroll when mobile menu is open
+    useEffect(() => {
+        if (isOpen) {
+            document.body.classList.add('mobile-menu-open');
+        } else {
+            document.body.classList.remove('mobile-menu-open');
+        }
+
+        // Cleanup on unmount
+        return () => {
+            document.body.classList.remove('mobile-menu-open');
+        };
+    }, [isOpen]);
 
     return (
         <nav className="fixed top-0 left-0 right-0 bg-white shadow-sm z-50">
@@ -87,28 +120,35 @@ export default function Navigation() {
                     {/* Mobile Menu Button */}
                     <button
                         onClick={() => setIsOpen(!isOpen)}
-                        className="md:hidden p-2 hover:bg-gray-100 rounded-lg"
+                        className="nav-button touch-target md:hidden p-2 hover:bg-gray-100 active:bg-gray-200 rounded-lg transition-colors touch-manipulation"
+                        aria-label={isOpen ? 'Close menu' : 'Open menu'}
+                        aria-expanded={isOpen}
                     >
-                        {isOpen ? (
-                            <X className="w-6 h-6" />
-                        ) : (
-                            <Menu className="w-6 h-6" />
-                        )}
+                        <div className="relative w-6 h-6">
+                            <Menu className={`absolute inset-0 w-6 h-6 transition-all duration-200 ${
+                                isOpen ? 'rotate-90 opacity-0' : 'rotate-0 opacity-100'
+                            }`} />
+                            <X className={`absolute inset-0 w-6 h-6 transition-all duration-200 ${
+                                isOpen ? 'rotate-0 opacity-100' : '-rotate-90 opacity-0'
+                            }`} />
+                        </div>
                     </button>
                 </div>
 
                 {/* Mobile Navigation */}
-                {isOpen && (
-                    <div className="md:hidden pb-4 space-y-2">
+                <div className={`mobile-menu-container md:hidden overflow-hidden transition-all duration-300 ease-in-out ${
+                    isOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+                }`}>
+                    <div className="pb-4 pt-2 space-y-1 bg-white border-t border-gray-100">
                         {navItems.map((item) => (
                             <Link
                                 key={item.path}
                                 to={item.path}
                                 onClick={() => setIsOpen(false)}
-                                className={`block px-4 py-2 rounded-lg font-semibold transition ${
+                                className={`nav-link mobile-nav-link touch-target block px-4 py-3 rounded-lg font-semibold transition-colors touch-manipulation ${
                                     isActive(item.path)
                                         ? 'bg-teal-500 text-white'
-                                        : 'text-gray-700 hover:bg-gray-100'
+                                        : 'text-gray-700 hover:bg-gray-100 active:bg-gray-200'
                                 }`}
                             >
                                 {item.label}
@@ -119,10 +159,10 @@ export default function Navigation() {
                         <Link
                             to="/favorites"
                             onClick={() => setIsOpen(false)}
-                            className={`flex items-center gap-2 px-4 py-2 rounded-lg font-semibold transition ${
+                            className={`nav-link mobile-nav-link touch-target flex items-center gap-2 px-4 py-3 rounded-lg font-semibold transition-colors touch-manipulation ${
                                 isActive('/favorites')
                                     ? 'bg-teal-500 text-white'
-                                    : 'text-gray-700 hover:bg-gray-100'
+                                    : 'text-gray-700 hover:bg-gray-100 active:bg-gray-200'
                             }`}
                         >
                             <Heart className={`w-5 h-5 ${favoriteIds.length > 0 ? 'fill-red-500 text-red-500' : ''}`} />
@@ -134,15 +174,17 @@ export default function Navigation() {
                             )}
                         </Link>
 
-                        <Link
-                            to="/signup"
-                            className="block w-full bg-orange-500 hover:bg-orange-600 text-white px-6 py-2 rounded-lg font-semibold transition text-center"
-                            onClick={() => setIsOpen(false)}
-                        >
-                            Get Started
-                        </Link>
+                        <div className="pt-2">
+                            <Link
+                                to="/signup"
+                                className="nav-link mobile-nav-link touch-target block w-full bg-orange-500 hover:bg-orange-600 active:bg-orange-700 text-white px-6 py-3 rounded-lg font-semibold transition-colors text-center touch-manipulation"
+                                onClick={() => setIsOpen(false)}
+                            >
+                                Get Started
+                            </Link>
+                        </div>
                     </div>
-                )}
+                </div>
             </div>
         </nav>
     );


### PR DESCRIPTION
Currently, the navigation bar / header does not collapse into a mobile-friendly menu (like a hamburger icon) on small screens.
On mobile viewports, the navigation links can overflow or become hard to interact with, breaking usability on phones and tablets.

This negatively impacts mobile users, who make up a large portion of web traffic and expect straightforward navigation.
This issue is not currently covered in the existing issues list