### PR TITLE
fix(plan-trip): reset form state after submission

### DIFF
--- a/frontend/src/pages/PlanTrip.jsx
+++ b/frontend/src/pages/PlanTrip.jsx
@@ -39,6 +39,12 @@ export default function PlanTrip() {
     console.log("Planned Trip Data:", formData);
 
     alert("Trip preferences saved! (AI itinerary coming soon)");
+    setFormData({
+      destination: "",
+      duration: "",
+      budget: "",
+      interests: [],
+    })
   }
 
   return (
@@ -113,11 +119,10 @@ export default function PlanTrip() {
                   key={interest}
                   type="button"
                   onClick={() => toggleInterest(interest)}
-                  className={`px-4 py-2 rounded-full border transition ${
-                    formData.interests.includes(interest)
+                  className={`px-4 py-2 rounded-full border transition ${formData.interests.includes(interest)
                       ? "bg-teal-500 text-white border-teal-500"
                       : "bg-white dark:bg-gray-950 border-gray-300 dark:border-gray-700"
-                  }`}
+                    }`}
                 >
                   {interest}
                 </button>


### PR DESCRIPTION
Clears all form fields after successful submission to improve user experience. 
Ensures the trip planner form resets properly so users can start a new entry without refreshing the page.
<img width="1039" height="784" alt="Screenshot 2026-01-13 185701" src="https://github.com/user-attachments/assets/eb639d16-f8b7-42ac-a9c0-ec90b64cb10b" />
