### PR TITLE
feat: add count-up animation for travelers section

### DIFF
--- a/frontend/src/components/CountUp.jsx
+++ b/frontend/src/components/CountUp.jsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from "react";
+
+const CountUp = ({ start = 1000, end = 50000, duration = 2500 }) => {
+  const [count, setCount] = useState(start);
+  const ref = useRef(null);
+  const hasAnimated = useRef(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !hasAnimated.current) {
+          hasAnimated.current = true;
+
+          let startTime = null;
+
+          const animate = (timestamp) => {
+            if (!startTime) startTime = timestamp;
+            const progress = Math.min(
+              (timestamp - startTime) / duration,
+              1
+            );
+
+            const value = Math.floor(
+              start + progress * (end - start)
+            );
+
+            setCount(value);
+
+            if (progress < 1) {
+              requestAnimationFrame(animate);
+            }
+          };
+
+          requestAnimationFrame(animate);
+        }
+      },
+      { threshold: 0.4 }
+    );
+
+    if (ref.current) observer.observe(ref.current);
+
+    return () => observer.disconnect();
+  }, [start, end, duration]);
+
+  return (
+    <span ref={ref}>
+      {count.toLocaleString()}+
+    </span>
+  );
+};
+
+export default CountUp;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -15,6 +15,7 @@ import {
   Award,
   Star,
 } from "lucide-react";
+import CountUp from "../components/CountUp";
 
 export default function Home() {
   return (
@@ -287,7 +288,7 @@ export default function Home() {
             <div className="text-center text-white px-4">
               <Users className="w-20 h-20 mx-auto mb-6 opacity-80" />
               <h3 className="text-3xl md:text-4xl font-bold mb-4">
-                Join 50,000+ Travelers
+                Join <CountUp/> Travelers
               </h3>
               <p className="text-lg mb-6 opacity-90">
                 Start your journey with the smartest travel assistant


### PR DESCRIPTION
Fixes #188 

This PR introduces a smooth count-up animation for the “Join Travelers” CTA section.
The number animates from 1,000 to 50,000 when the section becomes visible, creating a more engaging and dynamic user experience.

Implementation Details
- Uses IntersectionObserver to trigger animation on scroll
- Uses requestAnimationFrame for smooth animation
- Animation runs once per page load
- No external libraries added
- Fully reusable CountUp component

Result-


https://github.com/user-attachments/assets/07c133df-6896-4027-ae6f-23012d325b05


