### PR TITLE
Fixed the navbar issue where the features section opened in the middl…

### DIFF
--- a/frontend/src/pages/Features.jsx
+++ b/frontend/src/pages/Features.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import {
   MapPin,
@@ -19,6 +19,10 @@ import {
 } from 'lucide-react';
 
 export default function Features() {
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, []);
+
   return (
     <div className="min-h-screen bg-white dark:bg-gray-950">
       {/* Hero Section */}


### PR DESCRIPTION
#222 #GSSoC 
I have fixed the issue where previously the features tab on the navbar used to open in the middle of the features section. Now it properly opens at the start of the features section.