### PR TITLE
Updated ReadME for GSSOC'2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
-[![SWOC'26](https://img.shields.io/badge/SWOC-2026-blue.svg)](https://socialwinterofcode.com/)
+[![GSSoC'2026](https://img.shields.io/badge/GSSoC-2026-blue.svg)](https://gssoc.girlscript.org/)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ TourEase is fully responsive and works seamlessly across devices.
 
 ---
 
-## 🚀 Quick Start (SWOC'26)
+## 🚀 Quick Start (GSSoC'2026)
 
 To get the project running in under 2 minutes:
 
 1. **Clone the Repo**
    ```bash
-   git clone [https://github.com/Suhani1234-5/TourEase.git](https://github.com/Suhani1234-5/TourEase.git)
+   git clone https://github.com/Suhani1234-5/TourEase.git
    cd TourEase
    ```
 2. **Install & Run**
@@ -174,7 +174,7 @@ npm start
 
 ## 🤝 Contributing
 
-Joining us for **SWOC'26**? We love PRs! 🚀
+Joining us for **GSSoC'2026**? We love PRs! 🚀
 
 * Please read our **[Contributing Guidelines](CONTRIBUTING.md)** to get started.
 * Check out the **Project Roadmap** in our issues for open tasks.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,7 +60,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1596,7 +1595,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1638,7 +1636,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1744,7 +1741,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2000,7 +1996,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2949,7 +2944,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3010,7 +3004,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3020,7 +3013,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3301,7 +3293,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
Fixed the documentation issue by updating all occurrences of SWOC'2026 to GSSoC'2026 in the README for accurate branding consistency.

<img width="865" height="243" alt="image" src="https://github.com/user-attachments/assets/8f58c3c3-048a-4f69-b6d7-2f57bb935567" />
<img width="1136" height="257" alt="image" src="https://github.com/user-attachments/assets/c2f7cbc8-e260-4696-a64d-7243cbeb46d4" />
