### PR TITLE
404 Error on hard refresh for non-home routes (Vercel deployment) #274

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Which issue does this PR close?


- Closes #274 .

## Rationale for this change

The frontend is a Single Page Application (SPA) built with React and hosted on Vercel. Because the app utilizes client-side routing, Vercel natively throws a 404 Not Found error when users hard-refresh or directly visit non-root routes (such as /about), as there are no physical .html files for those specific paths. This change configures Vercel to route all unhandled requests back to index.html so React Router can properly take over.

## What changes are included in this PR?

Added a vercel.json configuration file to the root of the frontend directory.  

Configured a rewrite rule in vercel.json to map all source routes /(.*) to the destination: /index.html.

## Are these changes tested?

Yes. Deployed the branch to Vercel and verified that hard-refreshing non-root pages (e.g., /about and /contact) successfully loads the application without throwing a 404 error. Internal router navigation remains unaffected.

## Are there any user-facing changes?

Yes. Users can now safely refresh their browsers or share direct links to specific pages within the application without encountering broken pages.
Before change , on hard refreshing non home page route
<img width="1756" height="863" alt="image" src="https://github.com/user-attachments/assets/c75fbf6e-43b1-4072-8f43-cf2d364ba450" />
After change, on hard refreshing non home page route
<img width="1663" height="935" alt="image" src="https://github.com/user-attachments/assets/1e3e139f-2fad-4f6d-b03a-140756fdb791" />
