### PR TITLE
fix: improve color contrast for input fields in dark mode

### DIFF
--- a/frontend/src/pages/AddFavorite.jsx
+++ b/frontend/src/pages/AddFavorite.jsx
@@ -44,7 +44,7 @@ export default function AddFavorite() {
                 placeholder="Search favorites..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-full md:w-72 px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 dark:bg-gray-900 dark:border-gray-700 dark:text-white"
+                className="w-full md:w-72 px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-teal-500 dark:bg-gray-900 dark:border-gray-700 dark:text-white placeholder-gray-400 dark:placeholder-gray-500"
               />
             </div>
 

--- a/frontend/src/pages/Destinations.jsx
+++ b/frontend/src/pages/Destinations.jsx
@@ -72,7 +72,7 @@ export default function Destinations() {
               placeholder="Search destinations by name, type, or season..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-12 pr-4 py-4 rounded-full border-2 border-gray-200 dark:border-slate-700 focus:border-teal-500 dark:focus:border-teal-400 focus:outline-none text-lg bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100"
+              className="w-full pl-12 pr-4 py-4 rounded-full border-2 border-gray-200 dark:border-slate-700 focus:border-teal-500 dark:focus:border-teal-400 focus:outline-none text-lg bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-500"
             />
           </div>
         </div>

--- a/frontend/src/pages/PlanTrip.jsx
+++ b/frontend/src/pages/PlanTrip.jsx
@@ -67,7 +67,7 @@ export default function PlanTrip() {
               value={formData.destination}
               onChange={handleChange}
               required
-              className="w-full border rounded-lg px-4 py-3 bg-white dark:bg-gray-950 border-gray-300 dark:border-gray-700"
+              className="w-full border rounded-lg px-4 py-3 bg-white dark:bg-gray-950 border-gray-300 dark:border-gray-700 text-gray-900 dark:text-white"
             >
               <option value="">Select a destination</option>
               {destinations.map((d) => (
@@ -89,7 +89,7 @@ export default function PlanTrip() {
               required
               min="1"
               placeholder="e.g. 5"
-              className="w-full border rounded-lg px-4 py-3 bg-white dark:bg-gray-950 border-gray-300 dark:border-gray-700"
+              className="w-full border rounded-lg px-4 py-3 bg-white dark:bg-gray-950 border-gray-300 dark:border-gray-700 text-gray-900 dark:text-white"
             />
           </div>
 
@@ -101,7 +101,7 @@ export default function PlanTrip() {
               value={formData.budget}
               onChange={handleChange}
               required
-              className="w-full border rounded-lg px-4 py-3 bg-white dark:bg-gray-950 border-gray-300 dark:border-gray-700"
+              className="w-full border rounded-lg px-4 py-3 bg-white dark:bg-gray-950 border-gray-300 dark:border-gray-700 text-gray-900 dark:text-white"
             >
               <option value="">Select budget range</option>
               <option value="$">Budget ($)</option>

--- a/frontend/src/pages/TripPlanner.jsx
+++ b/frontend/src/pages/TripPlanner.jsx
@@ -257,7 +257,7 @@ export default function TripPlanner() {
               onChange={(e) => setRefinementInput(e.target.value)}
               placeholder="e.g. Make it more budget friendly, add local food spots..."
               rows={3}
-              className="w-full p-4 rounded-xl bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 outline-none focus:ring-2 focus:ring-teal-500/20"
+              className="w-full p-4 rounded-xl bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 outline-none focus:ring-2 focus:ring-teal-500/20 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500"
             />
             <button
               onClick={handleRefine}
@@ -282,7 +282,7 @@ export default function TripPlanner() {
   }
 
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-950">
+    <div className="min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-white">
       <div className="relative bg-gradient-to-br from-teal-500 via-teal-600 to-cyan-600 text-white py-20 text-center overflow-hidden">
         <div className="relative max-w-7xl mx-auto px-6 z-10">
           <div className="inline-flex items-center space-x-2 bg-white/10 border border-white/20 backdrop-blur-xl px-4 py-1.5 rounded-full mb-6">
@@ -334,7 +334,7 @@ export default function TripPlanner() {
                   value={formData.destination}
                   onChange={(e) => setFormData({ ...formData, destination: e.target.value })}
                   placeholder="e.g., Paris, Tokyo, Bali..."
-                  className="w-full bg-gray-50 dark:bg-gray-800 border dark:border-gray-700 rounded-xl px-6 py-4 text-lg outline-none focus:ring-2 focus:ring-teal-500/20"
+                  className="w-full bg-gray-50 dark:bg-gray-800 border dark:border-gray-700 rounded-xl px-6 py-4 text-lg outline-none focus:ring-2 focus:ring-teal-500/20 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-400"
                 />
               </div>
               <div className="grid md:grid-cols-2 gap-6">
@@ -342,13 +342,13 @@ export default function TripPlanner() {
                   <label className="flex items-center text-sm font-bold text-gray-700 dark:text-gray-300 mb-3 uppercase tracking-wider">
                     <Calendar className="w-5 h-5 mr-2 text-teal-500" /> Start Date
                   </label>
-                  <input type="date" value={formData.startDate} onChange={(e) => setFormData({ ...formData, startDate: e.target.value })} className="w-full bg-gray-50 dark:bg-gray-800 border rounded-xl px-6 py-4 outline-none" />
+                  <input type="date" value={formData.startDate} onChange={(e) => setFormData({ ...formData, startDate: e.target.value })} className="w-full bg-gray-50 dark:bg-gray-800 border dark:border-gray-700 rounded-xl px-6 py-4 outline-none text-gray-900 dark:text-white" />
                 </div>
                 <div className="bg-white dark:bg-gray-900 rounded-2xl p-8 shadow-xl border dark:border-gray-800">
                   <label className="flex items-center text-sm font-bold text-gray-700 dark:text-gray-300 mb-3 uppercase tracking-wider">
                     <Calendar className="w-5 h-5 mr-2 text-orange-500" /> End Date
                   </label>
-                  <input type="date" value={formData.endDate} onChange={(e) => setFormData({ ...formData, endDate: e.target.value })} className="w-full bg-gray-50 dark:bg-gray-800 border rounded-xl px-6 py-4 outline-none" />
+                  <input type="date" value={formData.endDate} onChange={(e) => setFormData({ ...formData, endDate: e.target.value })} className="w-full bg-gray-50 dark:bg-gray-800 border dark:border-gray-700 rounded-xl px-6 py-4 outline-none text-gray-900 dark:text-white" />
                 </div>
               </div>
             </div>
@@ -391,7 +391,7 @@ export default function TripPlanner() {
                 <label className="flex items-center text-sm font-bold text-gray-700 dark:text-gray-300 mb-4 uppercase tracking-wider"><DollarSign className="w-5 h-5 mr-2 text-teal-500" /> Budget Range</label>
                 <div className="grid grid-cols-3 gap-4">
                   {['budget', 'moderate', 'luxury'].map((b) => (
-                    <button key={b} onClick={() => setFormData({ ...formData, budget: b })} className={`py-4 px-6 rounded-xl font-bold transition-all ${formData.budget === b ? 'bg-teal-500 text-white shadow-lg shadow-teal-500/40' : 'bg-gray-100 dark:bg-gray-800'}`}>
+                    <button key={b} onClick={() => setFormData({ ...formData, budget: b })} className={`py-4 px-6 rounded-xl font-bold transition-all ${formData.budget === b ? 'bg-teal-500 text-white shadow-lg shadow-teal-500/40' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'}`}>
                       {b.charAt(0).toUpperCase() + b.slice(1)}
                     </button>
                   ))}


### PR DESCRIPTION
This change updates TripPlanner, PlanTrip, Destinations, and AddFavorite pages to ensure input text and placeholders are clearly visible against dark backgrounds by adding explicit text-white and placeholder-gray colors.