### PR TITLE
fix(ui): suppress browser native password reveal icons to prevent ove…

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -202,3 +202,17 @@ body > .skiptranslate {
     padding: 3px 8px;
   }
 }
+
+/* Hide browser-default native password reveal buttons in Microsoft Edge/IE */
+input::-ms-reveal,
+input::-ms-clear {
+    display: none !important;
+}
+
+/* Hide native browser validation reveal or fill buttons in WebKit browsers (Chrome, Safari, Opera) */
+input::-webkit-contacts-auto-fill-button,
+input::-webkit-credentials-auto-fill-button {
+    visibility: hidden !important;
+    display: none !important;
+    pointer-events: none !important;
+}


### PR DESCRIPTION
## Summary

- **What problem does this PR solve?**
  When typing a password on Chromium-based browsers (Chrome, Edge), the browser forces its default native password reveal visibility eye button into the field. This causes an overlapping visual glitch with our custom interactive toggle button on the login and registration pages.

- **What changed?**
  - Injected global cross-browser pseudo-element rules (`::-ms-reveal`, `::-ms-clear`, and `::-webkit-credentials-auto-fill-button`) inside `frontend/src/index.css` to explicitly turn off native browser button injections.

## Validation
- [x] Tested locally on Chrome / Microsoft Edge. The browser-native reveal button is completely suppressed, leaving our custom interactive design fully functional and clean.

## Related Issue
Closes #315 