### PR TITLE
Fix: scroll to top on route change via footer navigation links

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,7 @@ import NotFound from "./components/NotFound";
 import TripPlanner from './pages/TripPlanner';
 import Footer from "./components/Footer";
 import WatchDemoPage from './pages/DemoSection';
+import ScrollToTopOnNavigate from "./components/common/ScrollToTopOnNavigate";
 
 function ProtectedRoute({ children }) {
   const isAuthenticated = Boolean(localStorage.getItem("token"));
@@ -56,6 +57,7 @@ function AppRoutes() {
 
   return (
     <>
+      <ScrollToTopOnNavigate /> 
       {showNavigation && <Navigation />}
       <ScrollToTopButton />
       <LanguageSelector />

--- a/frontend/src/components/common/ScrollToTopOnNavigate.jsx
+++ b/frontend/src/components/common/ScrollToTopOnNavigate.jsx
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+const ScrollToTopOnNavigate = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTopOnNavigate;


### PR DESCRIPTION
## Summary
Fixed the issue where clicking footer navigation links (Features, Destinations, Plan Trip, About Us, Contact, Privacy, Terms) would navigate to the correct page but leave the user scrolled at the bottom or middle of the page instead of the top.

## What Was Changed
Created a new `ScrollToTopOnNavigate.jsx` component that listens for route changes using React Router's `useLocation` hook and calls `window.scrollTo({ top: 0, behavior: "smooth" })` every time the pathname changes. Imported and added `<ScrollToTopOnNavigate />` inside `AppRoutes()` in `App.jsx`.

## Files Changed
- `frontend/src/components/common/ScrollToTopOnNavigate.jsx` — new file created
- `frontend/src/App.jsx` — imported and added the new component

## How to Test
1. Open the app and scroll to the bottom of any page
2. Click any footer link (Features, Privacy, Terms, etc.)
3. The page should now scroll to the top smoothly after navigation

## Contribution Checklist
- [X] My code follows the project style.
- [X] I have updated the documentation (if applicable).
- [X] My PR title is descriptive.
- [X] I have tested the changes locally.

Closes #293 