### PR TITLE
Fix : Testimonials carousel doesn't pause on hover

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,19 @@
 @import "tailwindcss";
 @custom-variant dark (&:where(.dark, .dark *));
 
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
+.marquee-track {
+  animation: marquee 30s linear infinite;
+}
+
+.marquee-track:hover {
+  animation-play-state: paused;
+}
+
 * {
   transition-property: background-color, border-color, color, fill, stroke;
   transition-duration: 300ms;

--- a/frontend/src/pages/Testimonials.jsx
+++ b/frontend/src/pages/Testimonials.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 const testimonials = [
   {
@@ -18,7 +18,7 @@ const testimonials = [
   {
     name: "Rohan Verma",
     review:
-      "One of the best travel planning platforms I’ve used so far.",
+      "One of the best travel planning platforms I've used so far.",
     image: "https://i.pravatar.cc/150?img=45",
     rating: 5,
   },
@@ -32,15 +32,7 @@ const testimonials = [
 ];
 
 export default function Testimonials() {
-  const [offset, setOffset] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setOffset((prev) => prev - 1);
-    }, 20);
-
-    return () => clearInterval(interval);
-  }, []);
+  const [isPaused, setIsPaused] = useState(false);
 
   return (
     <section className="py-20 bg-gray-50 dark:bg-gray-950 overflow-hidden">
@@ -49,13 +41,12 @@ export default function Testimonials() {
           What Travelers Say
         </h2>
 
-        <div className="relative w-full">
+        <div className="relative w-full overflow-hidden">
           <div
-            className="flex gap-6 w-max"
-            style={{
-              transform: `translateX(${offset}px)`,
-              transition: "transform 0.02s linear",
-            }}
+            className="marquee-track flex gap-6 w-max"
+            style={{ animationPlayState: isPaused ? "paused" : "running" }}
+            onMouseEnter={() => setIsPaused(true)}
+            onMouseLeave={() => setIsPaused(false)}
           >
             {[...testimonials, ...testimonials].map((t, i) => (
               <div
@@ -81,24 +72,19 @@ export default function Testimonials() {
                     alt={t.name}
                     className="w-14 h-14 rounded-full object-cover"
                   />
-
                   <div>
                     <h4 className="font-semibold text-gray-900 dark:text-white">
                       {t.name}
                     </h4>
-
                     <div className="text-yellow-400 text-sm">
                       {[...Array(5)].map((_, j) => (
-                        <span key={j}>
-                          {j < t.rating ? "★" : "☆"}
-                        </span>
+                        <span key={j}>{j < t.rating ? "★" : "☆"}</span>
                       ))}
                     </div>
                   </div>
                 </div>
-
                 <p className="text-sm italic text-gray-600 dark:text-gray-400">
-                  “{t.review}”
+                  "{t.review}"
                 </p>
               </div>
             ))}


### PR DESCRIPTION
### Related Issue

Closes #351 
### Summary

1. Added @keyframes marquee, .marquee-track, and .marquee-track:hover to index.css to drive the infinite scroll animation via CSS
2. Refactored Testimonials.jsx to use the .marquee-track class instead of a JS setInterval offset approach
3. Added isPaused state (useState) toggled by onMouseEnter / onMouseLeave on the track container, binding animationPlayState to pause/resume the scroll on hover

### Before

1. Testimonial cards were static — no scrolling animation (missing @keyframes definition)
2. Previous JS interval implementation had no hover-pause support and no infinite loop reset logic

### After

1. Cards scroll continuously in a seamless infinite loop
2. Hovering over any card pauses the animation; moving away resumes it
3. No visual regression — no mask/white-fade on edges, dark mode and card styles preserved

 ### Testing

1.  Cards scroll automatically on page load
2. Hovering over a card pauses the scroll
3. Moving cursor away resumes the scroll
4. Works in both light and dark mode
5. No layout shift or overflow issues on mobile

Hey @Suhani1234-5, I've implemented the fix for this issue and raised the PR. Since I was the one who reported issue #351, I'd appreciate it if you could assign this to me and review when you get a chance. Thanks!