### PR TITLE
Fix geocoding fallback error propagation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,10 +1,17 @@
+const dotenv = require("dotenv");
+dotenv.config();
 const express = require("express");
 const mongoose = require("mongoose");
 const cors = require("cors");
-const dotenv = require("dotenv");
-const reviewRoutes = require("./routes/reviewRoutes");
 
-dotenv.config();
+const reviewRoutes = require("./routes/reviewRoutes");
+const authRoutes = require('./routes/authRoutes');
+const contactRoutes = require('./routes/contactRoutes');
+const tripRouter = require('./routes/tripRoutes');
+const itineraryRoutes = require('./routes/itineraryRoutes');
+const eventRoutes = require('./routes/eventRoutes');
+const weatherRoutes = require('./routes/weatherRoutes');
+const smartPlannerRoutes = require('./routes/smartPlannerRoutes');
 
 const app = express();
 

--- a/backend/services/weatherService.js
+++ b/backend/services/weatherService.js
@@ -42,28 +42,24 @@ class WeatherService {
     }
 
     // Convert location name to coordinates
+        // Convert location name to coordinates
     async _geocodeLocation(location) {
-        try {
-            const response = await axios.get(`${this.baseURL}/../geo/1.0/direct`, {
-                params: {
-                    q: location,
-                    limit: 1,
-                    appid: this.apiKey
-                }
-            });
-
-            if (response.data.length > 0) {
-                return {
-                    lat: response.data[0].lat,
-                    lon: response.data[0].lon
-                };
+        const response = await axios.get(`${this.baseURL}/../geo/1.0/direct`, {
+            params: {
+                q: location,
+                limit: 1,
+                appid: this.apiKey
             }
+        });
 
-            throw new Error('Location not found');
-        } catch (error) {
-            // Return default coords if geocoding fails
-            return { lat: 0, lon: 0 };
+        if (response.data.length > 0) {
+            return {
+                lat: response.data[0].lat,
+                lon: response.data[0].lon
+            };
         }
+
+        throw new Error('Location not found');
     }
 
     // Process raw forecast data into our format


### PR DESCRIPTION
## Fix Implemented

Resolved the issue where geocoding failures silently returned `{ lat: 0, lon: 0 }`, causing weather data to be fetched for Null Island instead of triggering fallback mock weather generation.

## Changes Made

* Removed silent fallback coordinates from `_geocodeLocation`
* Allowed geocoding failures to propagate correctly
* Ensured `getWeatherForecast` executes fallback mock weather generation

## Testing

* Tested using invalid location queries
* Verified backend logs display geocoding/API failure
* Confirmed fallback weather response is returned successfully

## Result

Invalid locations no longer fetch real weather data for coordinates `(0,0)`.

## Screenshots

<img width="1043" height="568" alt="Screenshot 2026-05-23 110341" src="https://github.com/user-attachments/assets/9addd8f4-ef74-4c3f-8502-7ce278efa103" />

<img width="824" height="214" alt="Screenshot 2026-05-23 110357" src="https://github.com/user-attachments/assets/75c8bf7a-70c5-49db-8388-7dc349f92c52" />

<img width="1919" height="378" alt="Screenshot 2026-05-23 110418" src="https://github.com/user-attachments/assets/42f55e44-da47-4d2c-b911-96b6da109668" />

Closes #363 
