### PR TITLE
fix: chatbot close button visibility and responsive layout on all screen sizes

### DIFF
--- a/frontend/src/components/chatbot/ChatbotContainer.jsx
+++ b/frontend/src/components/chatbot/ChatbotContainer.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { X, RotateCcw, Send } from "lucide-react";
+import "./chatbot.css"; 
 
 export default function ChatbotContainer({ onClose }) {
 

--- a/frontend/src/components/chatbot/chatbot.css
+++ b/frontend/src/components/chatbot/chatbot.css
@@ -22,6 +22,7 @@
   right: 24px;
   width: 380px; /* ⬅ bigger */
   height: 520px; /* ⬅ taller */
+  max-height: calc(100vh - 180px); 
   background: #ffffff;
   border-radius: 18px;
   box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
@@ -43,10 +44,21 @@
 }
 
 .chatbot-header button {
+  color: white;
+  background: transparent;
+  border: none;
+  cursor: pointer;
   opacity: 0.9;
+  padding: 4px 6px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease, opacity 0.15s ease;
 }
 .chatbot-header button:hover {
   opacity: 1;
+  background: rgba(255, 255, 255, 0.2);
 }
 
 .chatbot-body {
@@ -104,72 +116,6 @@
 
 .chatbot-footer button:hover {
   background: #ccfbf1;
-}
-
-/* =========================
-   MOBILE RESPONSIVE FIX
-   ========================= */
-
-@media (max-width: 640px) {
-  .chatbot-launcher {
-    bottom: 80px;
-    right: 16px;
-    height: 52px;
-    width: 52px;
-    font-size: 22px;
-  }
-
-  .chatbot-container {
-    width: calc(100vw - 24px);
-    height: calc(100vh - 120px);
-    right: 12px;
-    bottom: 90px;
-    border-radius: 16px;
-  }
-
-  .chatbot-body {
-    padding: 14px;
-    gap: 10px;
-  }
-
-  .chat-message {
-    font-size: 13px;
-    max-width: 85%;
-  }
-
-  .chatbot-footer {
-    flex-wrap: wrap;
-    gap: 8px;
-  }
-
-  .chatbot-footer button {
-    flex: 1 1 48%;
-    font-size: 12.5px;
-    padding: 9px;
-  }
-
-  .restart-btn {
-    font-size: 13px;
-    padding: 10px;
-  }
-}
-
-/* EXTRA SMALL DEVICES */
-@media (max-width: 400px) {
-  .chatbot-container {
-    width: calc(100vw - 16px);
-    height: calc(100vh - 100px);
-    right: 8px;
-  }
-
-  .chat-message {
-    font-size: 12.5px;
-  }
-
-  .chatbot-header {
-    font-size: 14px;
-    padding: 14px;
-  }
 }
 
 @keyframes fadeInUp {
@@ -330,4 +276,71 @@
       #f9fafb,
       #f3f4f6
     );
+}
+
+
+/* =========================
+   MOBILE RESPONSIVE FIX
+   ========================= */
+   
+@media (max-width: 640px) {
+  .chatbot-launcher {
+    bottom: 80px;
+    right: 16px;
+    height: 52px;
+    width: 52px;
+    font-size: 22px;
+  }
+
+  .chatbot-container {
+    width: calc(100vw - 24px);
+    height: calc(100vh - 120px);
+    right: 12px;
+    bottom: 90px;
+    border-radius: 16px;
+  }
+
+  .chatbot-body {
+    padding: 14px;
+    gap: 10px;
+  }
+
+  .chat-message {
+    font-size: 13px;
+    max-width: 85%;
+  }
+
+  .chatbot-footer {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .chatbot-footer button {
+    flex: 1 1 48%;
+    font-size: 12.5px;
+    padding: 9px;
+  }
+
+  .restart-btn {
+    font-size: 13px;
+    padding: 10px;
+  }
+}
+
+/* EXTRA SMALL DEVICES */
+@media (max-width: 400px) {
+  .chatbot-container {
+    width: calc(100vw - 16px);
+    height: calc(100vh - 100px);
+    right: 8px;
+  }
+
+  .chat-message {
+    font-size: 12.5px;
+  }
+
+  .chatbot-header {
+    font-size: 14px;
+    padding: 14px;
+  }
 }


### PR DESCRIPTION
## Problem
- Close (X) button was invisible on laptop/desktop screens
- Chatbot container height overflowed on smaller laptop screens
- Mobile layout was not resizing correctly on small devices

## Root Cause
`.chatbot-header button` had no `color` property set. Tailwind's 
preflight CSS reset was overriding the inherited white color from 
the parent, making the X icon invisible against the gradient header.

## Changes
- Added `color: white` to `.chatbot-header button` to fix invisible close button
- Added `max-height: calc(100vh - 180px)` to `.chatbot-container` to fix overflow on laptop
- Moved mobile media queries to bottom of CSS file so they correctly override desktop styles
- Added CSS import to `ChatbotContainer.jsx`

## Tested on
- Laptop screen ✅
- Mobile view (Galaxy S25) ✅
- Mobile view (iPhone SE) ✅

Closes #383 
<img width="1362" height="631" alt="Screenshot 2026-05-24 170011" src="https://github.com/user-attachments/assets/0f48b02a-4a6e-4185-80c9-b250d5d4e5a1" />
<img width="372" height="456" alt="Screenshot 2026-05-24 170029" src="https://github.com/user-attachments/assets/e4ec3fd0-c31b-41f1-975e-30f46f82e8f4" />
