### PR TITLE
fix: add auth middleware and ownership checks to review API routes

### DIFF
--- a/backend/controllers/reviewController.js
+++ b/backend/controllers/reviewController.js
@@ -34,7 +34,14 @@ const getReviewsByDestination = async (req, res) => {
 
 const createReview = async (req, res) => {
   try {
-    const review = await Review.create(req.body);
+    // Attach the authenticated user's ID to the review
+    const userId = req.user?.userId || req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ message: "Authentication required to create a review" });
+    }
+
+    const reviewData = { ...req.body, userId };
+    const review = await Review.create(reviewData);
 
     res.status(201).json(review);
   } catch (error) {
@@ -45,6 +52,19 @@ const createReview = async (req, res) => {
 const deleteReview = async (req, res) => {
   try {
     const { reviewId } = req.params; // Grab the ID from the URL
+
+    // Fetch the review to check ownership
+    const review = await Review.findById(reviewId);
+    if (!review) {
+      return res.status(404).json({ message: "Review not found" });
+    }
+
+    // Only the review owner or an admin can delete it
+    const currentUserId = req.user?.userId || req.user?.id;
+    const isAdmin = req.user?.role === "admin";
+    if (!isAdmin && review.userId && review.userId !== currentUserId) {
+      return res.status(403).json({ message: "You can only delete your own reviews" });
+    }
 
     await Review.findByIdAndDelete(reviewId);
 

--- a/backend/models/Review.js
+++ b/backend/models/Review.js
@@ -7,6 +7,12 @@ const reviewSchema = new mongoose.Schema(
       required: true,
     },
 
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+
     username: {
       type: String,
       required: true,

--- a/backend/routes/reviewRoutes.js
+++ b/backend/routes/reviewRoutes.js
@@ -5,12 +5,16 @@ const {
   deleteReview,
   likeReview,
 } = require("../controllers/reviewController");
+const { verifyToken } = require("../middleware/auth");
 
 const router = express.Router();
 
+// Public: anyone can read reviews
 router.get("/:destinationId", getReviewsByDestination);
-router.post("/:destinationId", createReview);
-router.delete("/:reviewId", deleteReview);
-router.patch("/:reviewId/like", likeReview);
+
+// Protected: must be logged in to create, delete, or like reviews
+router.post("/:destinationId", verifyToken, createReview);
+router.delete("/:reviewId", verifyToken, deleteReview);
+router.patch("/:reviewId/like", verifyToken, likeReview);
 
 module.exports = router;


### PR DESCRIPTION
Fixed the bug described in issue #402. The review API routes (POST, DELETE, PATCH) had no authentication/authorization checks, allowing any unauthenticated user to create, modify, or delete reviews.

**What was wrong:**
- POST /api/reviews/:destinationId — no auth required
- DELETE /api/reviews/:reviewId — no auth required  
- PATCH /api/reviews/:reviewId/like — no auth required
- deleteReview didn't check if the caller owned the review

**What I fixed:**
1. Added verifyToken middleware to POST, DELETE, and PATCH routes in reviewRoutes.js
2. Added userId field to Review schema for ownership tracking
3. Updated createReview to attach the authenticated user's ID
4. Added ownership check in deleteReview — only the review owner or admin can delete

Fixes #402.