### PR TITLE
fix: improve card hover effects visibility in dark mode

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -142,10 +142,10 @@ function FeatureCarousel({ cards }) {
                 padding: "0 12px",
               }}
             >
-              <div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-sm hover:shadow-lg transition-all duration-300 border border-gray-100 dark:border-gray-800 hover:border-teal-200 dark:hover:border-teal-700 group h-full">
+              <div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-sm hover:shadow-lg dark:hover:shadow-[0_0_25px_rgba(45,212,191,0.35)] transition-all duration-300 hover:-translate-y-2 border border-gray-100 dark:border-gray-800 hover:border-teal-200 dark:hover:border-teal-500 group h-full">
                 <div
-                  className={`${card.color} w-16 h-16 rounded-lg flex items-center justify-center mb-5 group-hover:scale-110 transition-transform`}
-                >
+  className={`${card.color} w-16 h-16 rounded-lg flex items-center justify-center mb-5 group-hover:scale-110 group-hover:rotate-3 transition-all duration-300`}
+>
                   {card.icon}
                 </div>
                 <h3 className="font-bold text-xl mb-3 text-gray-900 dark:text-white">
@@ -498,7 +498,7 @@ function StepCard({ number, icon, title, description, color }) {
       >
         {number}
       </div>
-      <div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-sm hover:shadow-md transition-all h-full border border-gray-100 dark:border-gray-800">
+      <div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-sm hover:shadow-md dark:hover:shadow-[0_0_20px_rgba(45,212,191,0.3)] hover:-translate-y-2 transition-all duration-300 h-full border border-gray-100 dark:border-gray-800 dark:hover:border-teal-500">
         <div className="bg-teal-100 dark:bg-teal-900/40 text-teal-600 dark:text-teal-300 w-14 h-14 rounded-lg flex items-center justify-center mx-auto mb-5">
           {icon}
         </div>


### PR DESCRIPTION
## 📄 Description

This PR fixes the issue where feature card hover effects were barely visible in dark mode.

### Changes Made
- Added stronger hover shadows for dark mode
- Added visible border glow on hover
- Added smooth transition animations
- Added slight lift effect on hover
- Improved hover visibility consistency across themes

### Result
Cards now provide clear interactive feedback in both light and dark modes.

---

## 🔗 Related Issues

Fixes #410

---

## ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes locally.
- [x] My changes do not break existing functionality.

---

##Screenshot

<img width="1847" height="796" alt="Screenshot 2026-05-25 120647" src="https://github.com/user-attachments/assets/d6c9e7b2-bcb3-4644-8967-017957a183bf" />

