### PR TITLE
Fix hover effect darkmode

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -515,7 +515,7 @@ function StepCard({ number, icon, title, description, color }) {
 
 function CommunityCard({ name, location, quote, trips }) {
   return (
-    <div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-sm border border-gray-100 dark:border-gray-800 hover:shadow-md transition-all">
+    <div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-sm border border-gray-100 dark:border-gray-800 hover:shadow-md dark:hover:shadow-[0_0_20px_rgba(45,212,191,0.3)] hover:-translate-y-2 transition-all duration-300 dark:hover:border-teal-500">
       <div className="flex items-center mb-6">
         <div className="w-14 h-14 bg-gradient-to-br from-teal-400 to-cyan-500 rounded-full flex items-center justify-center text-white font-bold text-xl mr-4">
           {name.charAt(0)}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -142,10 +142,10 @@ function FeatureCarousel({ cards }) {
                 padding: "0 12px",
               }}
             >
-              <div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-sm hover:shadow-lg transition-all duration-300 border border-gray-100 dark:border-gray-800 hover:border-teal-200 dark:hover:border-teal-700 group h-full">
+              <div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-sm hover:shadow-lg dark:hover:shadow-[0_0_25px_rgba(45,212,191,0.35)] transition-all duration-300 hover:-translate-y-2 border border-gray-100 dark:border-gray-800 hover:border-teal-200 dark:hover:border-teal-500 group h-full">
                 <div
-                  className={`${card.color} w-16 h-16 rounded-lg flex items-center justify-center mb-5 group-hover:scale-110 transition-transform`}
-                >
+  className={`${card.color} w-16 h-16 rounded-lg flex items-center justify-center mb-5 group-hover:scale-110 group-hover:rotate-3 transition-all duration-300`}
+>
                   {card.icon}
                 </div>
                 <h3 className="font-bold text-xl mb-3 text-gray-900 dark:text-white">
@@ -498,7 +498,7 @@ function StepCard({ number, icon, title, description, color }) {
       >
         {number}
       </div>
-      <div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-sm hover:shadow-md transition-all h-full border border-gray-100 dark:border-gray-800">
+      <div className="bg-white dark:bg-gray-900 p-8 rounded-xl shadow-sm hover:shadow-md dark:hover:shadow-[0_0_20px_rgba(45,212,191,0.3)] hover:-translate-y-2 transition-all duration-300 h-full border border-gray-100 dark:border-gray-800 dark:hover:border-teal-500">
         <div className="bg-teal-100 dark:bg-teal-900/40 text-teal-600 dark:text-teal-300 w-14 h-14 rounded-lg flex items-center justify-center mx-auto mb-5">
           {icon}
         </div>


### PR DESCRIPTION
## 📄 Description

This PR fixes the issue where testimonial/community card hover effects were barely visible in dark mode.

### Changes Made
- Added stronger hover glow and shadow effects for dark mode
- Improved hover contrast against dark card backgrounds
- Added smooth transition animations for better interaction feedback
- Added slight card elevation effect on hover
- Enhanced border visibility during hover state
- Maintained consistent hover behavior across light and dark themes

### Result
Testimonial cards now provide clear and visually noticeable hover feedback in both light and dark modes, improving overall UI consistency and user experience.

---

## 🔗 Related Issues

Fixes #411

---

## 🖼️ Screenshots

<img width="1863" height="725" alt="Screenshot 2026-05-25 121220" src="https://github.com/user-attachments/assets/92fa5fc1-d163-4990-8f32-7aa89abd9a8b" />


---

## 🧩 Type of Change

- [x] 🐛 Bug Fix
- [ ] ✨ New Feature
- [ ] ⚡ Enhancement / Optimization
- [ ] 🧰 Refactoring
- [ ] 🧾 Documentation Update
- [ ] 🔧 Other

---

## ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested the changes locally.
- [x] My changes do not break any existing functionality.
- [x] Hover effects work correctly in both light and dark themes.
- [x] I have linked the related issue.

---

## 💬 Additional Notes

This update improves interaction visibility and makes testimonial cards feel more interactive and polished, especially in dark mode.