### PR TITLE
Feat/tighten cors config [GSSOC'26]

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -28,7 +28,10 @@ const app = express();
 
 app.use(helmet());
 app.use(morgan("dev")); // use "combined" in production
-app.use(cors());
+app.use(cors({
+  origin: process.env.CLIENT_URL || "http://localhost:3000",
+  credentials: true,
+}));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,6 +16,8 @@ const weatherRoutes = require("./routes/weatherRoutes");
 const chatRoutes = require("./routes/chatroutes");
 const expenseRoutes = require("./routes/expenseRoutes");
 const helmet = require("helmet");
+const morgan = require("morgan");
+
 
 
 
@@ -25,7 +27,7 @@ connectDB();
 const app = express();
 
 app.use(helmet());
-
+app.use(morgan("dev")); // use "combined" in production
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));


### PR DESCRIPTION
Closes #436 

What does this PR do?
Restricts CORS to only allow requests from the configured client origin instead of all origins.
Problem
The server used cors() with no configuration, allowing requests from any domain. This is a security risk in production as it exposes all API endpoints to unauthorized origins.
Changes Made

Replaced app.use(cors()) with a restricted config in server.js
Reads allowed origin from CLIENT_URL environment variable
Falls back to http://localhost:3000 in development

Code Snippet
jsapp.use(cors({
  origin: process.env.CLIENT_URL || "http://localhost:3000",
  credentials: true,
}));
Type of Change

[x] New feature
[ ] Bug fix
[ ] Breaking change
[ ] Documentation update

Testing
[x] Server accepts requests from allowed origin
[x] Server blocks requests from unknown origins
[x] All existing routes unaffected


Branch: feat/tighten-cors-config → main

I would like to work on this issue under GSSoC.
Please assign this issue to me and add the gssoc and intermediate labels.