### PR TITLE
fix: remove hardcoded 2s fake loader delay in App.jsx

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -120,11 +120,7 @@ export default function App() {
   const [isLoading, setIsLoading] = React.useState(true);
 
   React.useEffect(() => {
-    // This simulates the app "loading" data for 2 seconds
-    const timer = setTimeout(() => {
-      setIsLoading(false);
-    }, 2000);
-    return () => clearTimeout(timer);
+    setIsLoading(false);
   }, []);
 
   if (isLoading) {


### PR DESCRIPTION
Closes #432 

## Changes Made
Removed the hardcoded 2 second setTimeout in App.jsx that was 
unnecessarily delaying page load on every refresh.

## Before
Users waited 2 seconds before seeing any content on every 
page load/refresh regardless of network speed.

## After
Page loads instantly with no artificial delay.