### PR TITLE
Fix: Navbar overflow and hidden CTA buttons on mid-sized screens

### DIFF
--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -117,7 +117,7 @@ export default function Navigation() {
           <div className="flex h-16 items-center justify-between">
 
             {/* DESKTOP NAV */}
-            <div className="hidden md:flex items-center gap-2 flex-1 justify-center px-8">
+            <div className="hidden min-[1200px]:flex items-center gap-2 flex-1 justify-center px-8">
               {navItems.map((item, index) => {
                 const hoverColors = [
                   "hover:bg-cyan-100 dark:hover:bg-cyan-900/30",
@@ -198,7 +198,7 @@ export default function Navigation() {
               {/* MOBILE MENU BUTTON */}
               <button
                 onClick={() => setIsOpen(!isOpen)}
-                className="md:hidden p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 text-gray-900 dark:text-white"
+                className="min-[1200px]:hidden p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-all duration-200 text-gray-900 dark:text-white"
               >
                 {isOpen ? (
                   <X className="w-6 h-6" />
@@ -214,7 +214,7 @@ export default function Navigation() {
       {/* MOBILE MENU BACKDROP */}
       <div
         className={`
-          fixed inset-0 z-30 md:hidden
+          fixed inset-0 z-30 min-[1200px]:hidden
           bg-black/50 backdrop-blur-sm
           ${isOpen ? "backdrop-open pointer-events-auto" : "backdrop-close pointer-events-none"}
         `}
@@ -224,7 +224,7 @@ export default function Navigation() {
       {/* MOBILE MENU DRAWER */}
       <div
         className={`
-          fixed inset-y-0 right-0 z-40 md:hidden
+          fixed inset-y-0 right-0 z-40 min-[1200px]:hidden
           w-72 bg-white dark:bg-gray-800 shadow-2xl border-l border-gray-200 dark:border-gray-700
           ${isOpen ? "menu-open" : "menu-close"}
         `}

--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -38,7 +38,6 @@ export default function Navigation() {
     navigate("/login", { replace: true });
   };
 
-
   return (
     <>
       <style>{`
@@ -100,8 +99,13 @@ export default function Navigation() {
       `}</style>
 
       <nav className="fixed top-0 left-0 right-0 z-50 bg-white dark:bg-gray-950 bg-gradient-to-b from-teal-50/50 to-transparent dark:from-gray-800/50 shadow-md border-b border-gray-200 dark:border-gray-800">
-        <div className="max-w-7xl mx-auto px-4 sm:px-4 lg:px-8 flex flex-row gap-5">
-          {/* LOGO */}
+        
+        {/* Outer Container: Uses clamp to reduce side padding on medium screens to buy more space */}
+        <div className="w-full px-[clamp(16px,2vw,48px)]">
+          
+          <div className="flex h-20 items-center justify-between w-full">
+            
+            {/* LOGO */}
             <div
               onClick={handleLogoClick}
               className="cursor-pointer flex items-center gap-2 group shrink-0"
@@ -114,10 +118,9 @@ export default function Navigation() {
                 TourEase
               </span>
             </div>
-          <div className="flex h-16 items-center justify-between">
 
-            {/* DESKTOP NAV */}
-            <div className="hidden min-[1200px]:flex items-center gap-2 flex-1 justify-center px-8">
+            {/* DESKTOP NAV (Breaks exactly at 1200px, but shrinks dynamically before that) */}
+            <div className="hidden min-[1200px]:flex items-center gap-[clamp(4px,0.8vw,8px)] flex-1 justify-center px-2">
               {navItems.map((item, index) => {
                 const hoverColors = [
                   "hover:bg-cyan-100 dark:hover:bg-cyan-900/30",
@@ -133,7 +136,7 @@ export default function Navigation() {
                   <Link
                     key={item.path}
                     to={item.path}
-                    className={`px-3 py-2 rounded-lg font-semibold whitespace-nowrap text-base transition-all ${isActive(item.path)
+                    className={`px-[clamp(6px,0.8vw,12px)] py-2 rounded-lg font-semibold whitespace-nowrap text-[clamp(12px,1vw,15px)] transition-all ${isActive(item.path)
                       ? "bg-teal-500 dark:bg-indigo-600 text-white"
                       : `text-gray-700 dark:text-gray-300 ${hoverColors[index]}`
                       }`}
@@ -144,15 +147,15 @@ export default function Navigation() {
               })}
               <Link
                 to="/favorites"
-                className={`group relative px-3 py-2 rounded-lg font-semibold flex items-center gap-2 whitespace-nowrap text-base transition ${isActive("/favorites")
+                className={`group relative px-[clamp(6px,0.8vw,12px)] py-2 rounded-lg font-semibold flex items-center gap-2 whitespace-nowrap text-[clamp(12px,1vw,15px)] transition ${isActive("/favorites")
                   ? "bg-teal-500 dark:bg-indigo-600 text-white"
                   : "text-gray-700 dark:text-gray-300 hover:bg-red-100 dark:hover:bg-red-900/30"
                   }`}
               >
-                <Heart className="w-5 h-5 transition-colors group-hover:text-red-500 group-hover:fill-red-500" />
+                <Heart className="w-5 h-5 transition-colors group-hover:text-red-500 group-hover:fill-red-500 shrink-0" />
                 Favorites
                 {favoriteIds.length > 0 && (
-                  <span className="absolute right-3 top-1/2 -translate-y-1/2 bg-red-500 text-white text-xs px-2 h-5 min-w-7 rounded-full inline-flex items-center justify-center">
+                  <span className="absolute right-2 top-1/2 -translate-y-1/2 bg-red-500 text-white text-xs px-2 h-5 min-w-7 rounded-full inline-flex items-center justify-center">
                     {favoriteIds.length}
                   </span>
                 )}
@@ -160,8 +163,7 @@ export default function Navigation() {
             </div>
 
             {/* RIGHT ACTIONS */}
-            <div className="flex items-center gap-4 shrink-0">
-
+            <div className="flex items-center gap-[clamp(8px,1vw,16px)] shrink-0">
               {/* THEME TOGGLE */}
               <button
                 onClick={toggleTheme}
@@ -179,17 +181,18 @@ export default function Navigation() {
                 )}
               </button>
 
-              {/* CTA */}
+              {/* CTA - Uses clamp to shrink padding and text proportionally */}
               {!isLoggedIn ? (
                 <Link
                   to="/login"
-                  className="bg-orange-500 hover:bg-orange-600 text-white px-6 py-2 rounded-lg font-semibold transition items-center w-33"
+                  className="bg-orange-500 hover:bg-orange-600 text-white px-[clamp(12px,1.5vw,24px)] py-2 rounded-lg font-semibold transition items-center whitespace-nowrap text-[clamp(12px,1vw,15px)]"
                 >
-                  Get Started</Link>
+                  Get Started
+                </Link>
               ) : (
                 <button
                   onClick={handleLogout}
-                  className="bg-red-500 hover:bg-red-600 text-white px-5 py-2 rounded-lg font-semibold transition whitespace-nowrap text-base shadow-lg hover:shadow-xl"
+                  className="bg-red-500 hover:bg-red-600 text-white px-[clamp(12px,1.5vw,20px)] py-2 rounded-lg font-semibold transition whitespace-nowrap text-[clamp(12px,1vw,15px)] shadow-lg hover:shadow-xl"
                 >
                   Logout
                 </button>
@@ -207,6 +210,7 @@ export default function Navigation() {
                 )}
               </button>
             </div>
+            
           </div>
         </div>
       </nav>
@@ -261,7 +265,7 @@ export default function Navigation() {
                   key={item.path}
                   to={item.path}
                   onClick={() => setIsOpen(false)}
-                  className={`block px-5 py-4 rounded-2xl font-semibold text-base transition-all duration-200 ${isActive(item.path)
+                  className={`block px-5 py-4 rounded-2xl font-semibold text-[15px] transition-all duration-200 ${isActive(item.path)
                     ? "bg-linear-to-r from-teal-500 to-cyan-600 dark:from-indigo-500 dark:to-purple-600 text-white shadow-lg"
                     : `text-gray-700 dark:text-gray-100 ${mobileHoverColors[index]}`
                     }`}
@@ -280,7 +284,7 @@ export default function Navigation() {
             <Link
               to="/favorites"
               onClick={() => setIsOpen(false)}
-              className={`group relative px-5 py-4 rounded-2xl font-semibold flex items-center gap-3 text-base transition-all duration-200 ${isActive("/favorites")
+              className={`group relative px-5 py-4 rounded-2xl font-semibold flex items-center gap-3 text-[15px] transition-all duration-200 ${isActive("/favorites")
                 ? "bg-linear-to-r from-teal-500 to-cyan-600 dark:from-indigo-500 dark:to-purple-600 text-white shadow-lg"
                 : "text-gray-700 dark:text-gray-100 hover:bg-red-100 dark:hover:bg-red-900/40"
                 }`}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

-Closes #451

-Closes #441

## Rationale for this change

The current navigation bar contains a high volume of elements (Logo, 8 Nav Links, Favorites, Theme Toggle, and Auth Buttons). Because these elements previously had fixed sizes and were confined within a max-w-7xl container, they mathematically could not fit horizontally on mid-sized screens. This caused severe UI overflow, pushing critical Call to Action buttons ("Get Started") completely off the screen and making them unclickable on viewports between 768px and ~1380px.

## What changes are included in this PR?

-Fluid Scaling: Replaced fixed padding, gaps, and font sizes with CSS clamp() functions. The navbar now dynamically and smoothly shrinks its internal spacing as the window resizes, preventing harsh cutoffs.  

-Updated Breakpoints: Changed the mobile hamburger menu trigger from md:hidden (768px) to min-[1200px]:hidden. This ensures the UI safely transitions to the mobile drawer before the horizontal layout breaks.

-Container Alignment: Removed the restrictive max-w-7xl mx-auto wrapper and replaced it with a full-width w-full container using fluid side padding to ensure perfectly symmetrical alignment on all screen sizes.

## Are these changes tested?

Yes. I have thoroughly tested these changes locally using browser Developer Tools (Responsive Design Mode). I verified the layout at extreme edge cases: mobile (320px), tablet (768px), the previously broken layout width (1254px), and ultra-wide desktop (1920px). The buttons are now 100% accessible and aligned at every breakpoint.

## Are there any user-facing changes?

Yes, a significantly improved UI for users on laptops and tablets. Users on viewports between 1200px and 1400px will now experience a fluidly scaling navigation bar that gracefully snaps into a mobile menu, ensuring they can always access the "Get Started" auth flow without it being hidden off-screen.