### PR TITLE
Improve dark-theme contrast and state clarity for Smart Planner interest tags (Fixes # 422)

### DIFF
--- a/frontend/src/components/smartPlanner/PlannerForm.jsx
+++ b/frontend/src/components/smartPlanner/PlannerForm.jsx
@@ -158,7 +158,7 @@ export default function PlannerForm({
                 key={interest}
                 type="button"
                 onClick={() => onToggleInterest(interest)}
-                className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/70 ${
+                className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500/70 dark:focus-visible:ring-teal-300 ${
                   selected
                     ? 'bg-orange-500 text-white border-orange-400 shadow-md shadow-orange-500/25 hover:bg-orange-400'
                     : 'bg-white dark:bg-gray-800/90 border-gray-300 dark:border-gray-400 text-gray-700 dark:text-gray-100 hover:border-teal-400 dark:hover:border-teal-300 hover:text-gray-900 dark:hover:text-white'

--- a/frontend/src/components/smartPlanner/PlannerForm.jsx
+++ b/frontend/src/components/smartPlanner/PlannerForm.jsx
@@ -158,10 +158,10 @@ export default function PlannerForm({
                 key={interest}
                 type="button"
                 onClick={() => onToggleInterest(interest)}
-                className={`px-3 py-1.5 rounded-full text-sm font-medium border transition ${
+                className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-400/70 ${
                   selected
-                    ? 'bg-orange-500 text-white border-orange-500'
-                    : 'border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-teal-400'
+                    ? 'bg-orange-500 text-white border-orange-400 shadow-md shadow-orange-500/25 hover:bg-orange-400'
+                    : 'bg-white dark:bg-gray-800/90 border-gray-300 dark:border-gray-400 text-gray-700 dark:text-gray-100 hover:border-teal-400 dark:hover:border-teal-300 hover:text-gray-900 dark:hover:text-white'
                 }`}
               >
                 {interest}


### PR DESCRIPTION
Interest tags in the Smart Planner “New plan” flow had low contrast in dark mode, making labels and borders hard to distinguish. Selected vs unselected states were visually weak, reducing readability and accessibility.


 Dark-mode contrast upgrades
- Increased unselected tag contrast with stronger dark border/text pairing.
- Added explicit dark background treatment for unselected chips to avoid blending into the form surface.

 State differentiation
- Strengthened selected-chip styling (border + fill + shadow) so active selections are immediately recognizable.
- Improved hover contrast for unselected tags in dark mode to make affordances clearer.
 
 Keyboard accessibility polish
- Added focus-visible ring styling with a dark-mode-specific ring color to keep focus indication obvious on dark backgrounds.

```
className={`... focus-visible:ring-2 focus-visible:ring-teal-500/70 dark:focus-visible:ring-teal-300 ${
  selected
    ? 'bg-orange-500 text-white border-orange-400 shadow-md shadow-orange-500/25 hover:bg-orange-400'
    : 'bg-white dark:bg-gray-800/90 border-gray-300 dark:border-gray-400 text-gray-700 dark:text-gray-100 hover:border-teal-400 dark:hover:border-teal-300 hover:text-gray-900 dark:hover:text-white'
}`}
```
@Suhani1234-5 Solved conflits