### PR TITLE
FIX: Protect favorites route for unauthenticated users

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -96,7 +96,7 @@ function AppRoutes() {
             <Route path="/auth" element={<PageTransition><Auth /></PageTransition>} />
             <Route path="/signup" element={<Navigate to="/auth?mode=signup" replace />} />
             <Route path="/login" element={<Navigate to="/auth?mode=login" replace />} />
-            <Route path="/favorites" element={<PageTransition><AddFavorite /></PageTransition>} />
+            <Route path="/favorites" element={<ProtectedRoute><PageTransition><AddFavorite /></PageTransition></ProtectedRoute>} />
             <Route path="/destinations/:id" element={<PageTransition><DestinationDetails /></PageTransition>} />
             <Route path="/plan-trip" element={<PageTransition><PlanTrip /></PageTransition>} />
             <Route path="/dynamic-planner" element={<PageTransition><DynamicPlannerPage /></PageTransition>} />


### PR DESCRIPTION
This PR fixes the issue where unauthenticated users could directly access the Favorites page.

- Wrapped the `/favorites` route with the existing `ProtectedRoute` component
- Ensured authentication is checked before rendering the Favorites page
- Redirects unauthenticated users to the login/auth page instead of allowing direct access

Fixes #401

Submitted under GSSoC'2026.