### PR TITLE
Fix duplicate getUserItineraries API method

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -166,10 +166,6 @@ export const api = {
     });
   },
 
-  async getUserItineraries() {
-    return this.request('/itinerary/user');
-  },
-
   // --- Split & Expense Tracker ---
   async getExpenseGroups() {
     return this.request('/expenses');


### PR DESCRIPTION
## Summary
- Remove duplicate getUserItineraries method from frontend/src/services/api.js
- Keep the existing itinerary API method used by MyTrips.jsx unchanged

## Testing
- npx eslint src/services/api.js
- npm run build
- rg "getUserItineraries" frontend/src -n

Note: npm run lint still reports pre-existing unrelated lint errors outside this PR.