### PR TITLE
fix: remove stray character causing Navigation runtime error

### DIFF
--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -6,7 +6,7 @@ import { useTheme } from "../context/useTheme";
 import LanguageSelector from "./LanguageSelector";
 
 export default function Navigation() {
-  const [isOpen, setIsOpen] = useState(false);a
+  const [isOpen, setIsOpen] = useState(false);
   const { theme, toggleTheme } = useTheme();
 
   const location = useLocation();


### PR DESCRIPTION
## Description
This PR fixes the runtime error reported in #506 caused by a stray character in Navigation.jsx.

## Changes made
- Removed unintended `a` character from: `/frontend/src/components/Navigation.jsx`

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Documentation update
- [ ] Refactoring
 
## Contribution Checklist
- [x] My code follows the project style.
- [x] I have updated the documentation (IF APPLICABLE).
- [x] My PR title is descriptive.
- [x] I have tested the changes locally.


Closes #506 