### PR TITLE
fix: remove duplicate project structure heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,9 @@ TourEase is an open-source, AI-powered travel assistant that helps tourists plan
 
 ---
 
-## 🗂️ Project Structure
+<!-- Removed duplicate Project Structure heading -->
 
 ## 🗂️ Project Structure
-
 ```text
 TourEase/
 ├── frontend/                        # React + Vite client (Mapped to Port 7000)


### PR DESCRIPTION
## Description

This PR removes the duplicate "Project Structure" heading from the README.

### Changes Made

* Removed the repeated "Project Structure" heading.
* Added a comment documenting the fix.
* Improved README formatting and consistency.

### Type of Change

* Documentation Fix

### Checklist

* [x] README updated
* [x] No code changes made
* [x] Formatting verified
