### PR TITLE
UI Fixing in Weather Forecast section

### DIFF
--- a/frontend/src/components/WeatherWidget.jsx
+++ b/frontend/src/components/WeatherWidget.jsx
@@ -61,10 +61,10 @@ const WeatherWidget = ({ weather }) => {
                         {/* Temperature */}
                         <div className="text-center mb-2">
                             <div className="text-2xl font-bold text-gray-900">
-                                {day.temp.max}°
+                                {Number(day.temp.max).toFixed(1)}°
                             </div>
                             <div className="text-xs text-gray-600">
-                                {day.temp.min}°
+                                {Number(day.temp.min).toFixed(1)}°
                             </div>
                         </div>
 
@@ -77,7 +77,7 @@ const WeatherWidget = ({ weather }) => {
                         {day.precipitation > 0 && (
                             <div className="flex items-center justify-center gap-1 text-xs text-blue-600">
                                 <Droplets className="w-3 h-3" />
-                                <span>{day.precipitation}%</span>
+                                <span>{Number(day.precipitation).toFixed(1)}%</span>
                             </div>
                         )}
 
@@ -85,7 +85,7 @@ const WeatherWidget = ({ weather }) => {
                         {day.windSpeed && day.windSpeed > 20 && (
                             <div className="flex items-center justify-center gap-1 text-xs text-gray-600 mt-1">
                                 <Wind className="w-3 h-3" />
-                                <span>{day.windSpeed} km/h</span>
+                                <span>{Number(day.windSpeed).toFixed(1)} km/h</span>
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
Issue Fixed: #513 

Description: 
The numeric values for temperature, rain probability, and wind speed in the weather forecast cards were displaying as raw, unrounded floating-point numbers (e.g., 30.1078845320...°), which caused the text to overflow and break the UI layout.

Changes Made: 
Modified frontend/src/components/WeatherWidget.jsx
 to wrap all weather metric variables using Number().toFixed(1). This ensures values are cleanly rounded to exactly one decimal place (e.g., 30.1°).

Testing:
Ran the application locally and generated a new AI itinerary.
Navigated to the Dynamic Plan page and reviewed the "Weather Forecast" section.
Verified that all temperature, precipitation, and wind speed numbers are correctly formatted with one decimal place and fit perfectly within their UI cards without any overflow.

Screenshot of Change:
<img width="1057" height="831" alt="image" src="https://github.com/user-attachments/assets/6a40af32-af19-4d0a-a387-5f5bc337b7ef" />


Hi @Suhani1234-5 ma'am, I have fixed issue #513 and created a PR please review it and merge it into the main branch.
Thankyou.