### PR TITLE
fix: remove duplicate require declarations in server.js

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const mongoose = require("mongoose");
 const cors = require("cors");
-const helmet = require("helmet");
 const dotenv = require("dotenv");
 const helmet = require("helmet");
 const morgan = require("morgan");


### PR DESCRIPTION
Closes #518 

---

## What was the problem?

`backend/server.js` had `helmet` imported twice:

```js
const helmet = require("helmet");  // line 4 ✅
const helmet = require("helmet");  // line 6 ❌ duplicate
```

Duplicate `const` declarations in the same scope are a `SyntaxError` in strict mode and cause the server to crash on startup in newer Node.js versions.

---

## Changes Made

- **`backend/server.js`** — removed the duplicate `const helmet = require("helmet")` declaration (line 6)

---

## Testing Done

- Ran `node server.js` locally — server starts cleanly with no `SyntaxError`
- All existing routes respond as expected

---

## Checklist

- [x] Code follows the project's existing style
- [x] Only one file changed (`backend/server.js`)
- [x] No new dependencies added
- [x] Tested locally before raising PR