### PR TITLE
fix: remove duplicate helmet import in server.js

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -3,7 +3,6 @@ const mongoose = require("mongoose");
 const cors = require("cors");
 const helmet = require("helmet");
 const dotenv = require("dotenv");
-const helmet = require("helmet");
 const morgan = require("morgan");
 const passport = require("./config/passport");
 


### PR DESCRIPTION
## What changed

* Removed the duplicate `const helmet = require("helmet")` declaration on line 6 of `backend/server.js`
* The first declaration on line 4 is retained; only the redundant second import is deleted
* No other lines or logic were modified

## Why

The backend server crashes immediately on startup with `SyntaxError` because `const` redeclaration in the same scope is illegal in JavaScript. The duplicate import was introduced during a merge where two branches independently added `helmet`. Without this fix, **no backend routes function at all**.

## How to test

Run the backend server:

```bash
cd backend
npm install
node server.js
```

Expected result:

* Server starts without `SyntaxError`

## Screenshots (if UI change)

N/A (Backend server startup fix only)

## Related issue

Closes #536

---

## Pre-Submission Checklist

* [x] Branch named following GSSoC convention: `fix/duplicate-helmet-require-server`
* [x] Changes committed with meaningful commit message
* [x] Changes pushed to remote fork
* [x] Relevant tests executed successfully
* [x] Code follows project contribution guidelines
