### PR TITLE
fix: remove nested footer elements and duplicate h3 brand heading

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -11,24 +11,18 @@ import {
 
 export default function Footer() {
   return (
-<footer className="bg-gradient-to-br from-slate-50 via-white to-teal-50 text-gray-600 dark:from-[#020617] dark:via-[#0b1120] dark:to-[#111827] dark:text-gray-400 py-16 relative overflow-hidden border-t border-gray-200 dark:border-transparent">
-  <div className="absolute -top-32 -left-32 h-72 w-72 rounded-full bg-teal-500/10 blur-3xl"></div>
+    <footer className="bg-gradient-to-br from-slate-50 via-white to-teal-50 text-gray-600 dark:from-[#020617] dark:via-[#0b1120] dark:to-[#111827] dark:text-gray-400 py-16 relative overflow-hidden border-t border-gray-200 dark:border-transparent">
+      <div className="absolute -top-32 -left-32 h-72 w-72 rounded-full bg-teal-500/10 blur-3xl"></div>
 
-<div className="absolute -bottom-32 -right-32 h-72 w-72 rounded-full bg-cyan-500/10 blur-3xl dark:bg-orange-500/10"></div>
-        <div className="absolute top-0 left-0 w-full h-px bg-linear-to-r from-transparent via-teal-500/40 to-transparent dark:via-orange-500/40"></div>
-    <footer className="bg-gray-50 text-gray-600 dark:bg-[#0b1120] dark:text-gray-400 py-16 relative overflow-hidden border-t border-gray-200 dark:border-transparent">
+      <div className="absolute -bottom-32 -right-32 h-72 w-72 rounded-full bg-cyan-500/10 blur-3xl dark:bg-orange-500/10"></div>
       <div className="absolute top-0 left-0 w-full h-px bg-linear-to-r from-transparent via-teal-500/40 to-transparent dark:via-orange-500/40"></div>
 
       <div className="max-w-7xl mx-auto px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-12 gap-12 mb-16">
           {/* Brand Section */}
           <div className="lg:col-span-4 space-y-6">
-<h3 className="text-gray-900 dark:text-white font-bold text-3xl tracking-tight transition-all duration-300 hover:scale-105 cursor-pointer">
-                Tour<span className="text-teal-600 dark:text-teal-400">Ease</span>
-
-            <h3 className="text-gray-900 dark:text-white font-bold text-3xl tracking-tight">
-              Tour
-              <span className="text-teal-600 dark:text-indigo-600">Ease</span>
+            <h3 className="text-gray-900 dark:text-white font-bold text-3xl tracking-tight transition-all duration-300 hover:scale-105 cursor-pointer">
+              Tour<span className="text-teal-600 dark:text-teal-400">Ease</span>
             </h3>
 
             <p className="text-sm text-gray-600 dark:text-gray-400 max-w-xs">


### PR DESCRIPTION
## What changed

* Removed the nested inner `<footer>` element at line 27 of `frontend/src/components/Footer.jsx` — only the outer `<footer>` (line 22) with gradient styling is retained
* Removed the duplicate `<h3>` brand heading (lines 37-40) — kept the version with `hover:scale-105` transition for better UX interactivity
* Ensured proper tag closure and valid HTML5 nesting throughout the component

## Why

The `Footer.jsx` component had two structural bugs:
1. **Nested `<footer>` inside `<footer>`** — This is invalid HTML per the W3C spec. It caused competing gradient backgrounds in dark mode, duplicate footer landmarks for screen readers, and inconsistent rendering across browsers.
2. **Duplicate `<h3>` brand headings** — Two "TourEase" headings rendered back-to-back due to a likely incomplete merge. Users saw the brand name printed twice in the footer area.

These issues likely originated from a merge where two PRs modified the Footer independently.

## How to test

Run the frontend dev server:

```bash
cd frontend
npm install
npm run dev
```

Then verify by opening the browser to any page and scrolling to the footer.

Expected result:

* Single "TourEase" brand text in footer (no duplication)
* Single `<footer>` element in DOM
* Consistent gradient background in both light and dark mode

## Screenshots (if UI change)

N/A

## Related issue

Closes #537

---

## Pre-Submission Checklist

* [x] Branch named following GSSoC convention: `fix/footer-nested-elements-duplicate-heading`
* [x] Changes committed with meaningful commit message
* [x] Changes pushed to remote fork
* [x] Relevant tests executed successfully
* [x] Code follows project contribution guidelines
