### PR TITLE
fix: add rate limiting and auth to trip generation routes

### DIFF
--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -1,0 +1,17 @@
+const rateLimit = require('express-rate-limit');
+
+// Rate limiter for AI trip generation to prevent API abuse
+const aiTripLimiter = rateLimit({
+  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000, // 15 minutes default
+  max: parseInt(process.env.RATE_LIMIT_MAX) || 10, // limit each IP to 10 requests per windowMs
+  message: {
+    success: false,
+    message: 'Too many trip generation requests from this IP. Please try again later.'
+  },
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
+module.exports = {
+  aiTripLimiter
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
         "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.2",
         "langchain": "^1.4.2",
@@ -917,6 +918,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1019,20 +1038,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1243,6 +1248,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1628,8 +1642,6 @@
     "node_modules/mongoose": {
       "version": "8.24.0",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.0.tgz",
-      
-      "integrity": "sha512-gHSPD8qEwRmiXapK17hEnFWZdcFENMegHTcw5XIIg2+7R8eXQvdwSiMpD/A2oG8tKzFLLHyRXd8/eaDPAVwZgQ==",
       "integrity": "sha512-EEZwOibDPZ5uZN3bFapfnRskEbdljAf6sP9ln6u+P4e5IfkOAh6Tqw2g8/Tag++KHOAJ095WXT/c0uqRq4Vckg==",
       "license": "MIT",
       "dependencies": {
@@ -1650,19 +1662,23 @@
       }
     },
     "node_modules/morgan": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+      "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
       "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
+        "on-finished": "~2.4.1",
         "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/morgan/node_modules/debug": {
@@ -1679,18 +1695,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/mpath": {
       "version": "0.9.0",
@@ -2132,7 +2136,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }    },
       }
     },
     "node_modules/pstree.remy": {
@@ -2162,10 +2165,6 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.2",
     "langchain": "^1.4.2",

--- a/backend/routes/tripRoutes.js
+++ b/backend/routes/tripRoutes.js
@@ -6,14 +6,17 @@ const {
   refineTrip,
 } = require("../controllers/tripController");
 
+const { verifyToken } = require("../middleware/auth");
+const { aiTripLimiter } = require("../middleware/rateLimiter");
+
 // @route   POST /api/trip/generate
 // @desc    Generate a weather-aware trip itinerary
-// @access  Public (No login required)
-router.post("/generate", generateTrip);
+// @access  Private (Login required)
+router.post("/generate", verifyToken, aiTripLimiter, generateTrip);
 
 // @route   POST /api/trip/refine
 // @desc    Refine an existing itinerary
-// @access  Public (No login required)
-router.post("/refine", refineTrip);
+// @access  Private (Login required)
+router.post("/refine", verifyToken, aiTripLimiter, refineTrip);
 
 module.exports = router;


### PR DESCRIPTION
## What changed

* Created new file `backend/middleware/rateLimiter.js` with a configurable `aiTripLimiter` using `express-rate-limit`
* Modified `backend/routes/tripRoutes.js`:
  - Added `verifyToken` middleware import from `../middleware/auth`
  - Applied `verifyToken` and `aiTripLimiter` to both `/generate` and `/refine` routes
* Added `express-rate-limit` as a dependency in `backend/package.json`

## Why

The `/api/trip/generate` and `/api/trip/refine` endpoints call an external AI provider (OpenRouter/OpenAI) on every request. Previously, they had:

- **No authentication** — Any anonymous user could trigger paid API calls
- **No rate limiting** — A simple loop could send thousands of requests, each consuming paid AI tokens

This created two critical vulnerabilities:
1. **Financial exposure** — AI API credits could be drained in minutes by a malicious actor
2. **Denial of service** — Exhausting the AI provider's rate limit would break trip generation for all users

The fix adds two layers of protection:
- `verifyToken` ensures only authenticated users can access these endpoints
- `aiTripLimiter` caps each IP to 10 requests per 15-minute window (configurable via `.env`)

## How to test

Test authentication:

```bash
# Request without auth token
curl -X POST http://localhost:5000/api/trip/generate \
  -H "Content-Type: application/json" \
  -d '{"destination":"Paris"}'
```

Expected result:

* Returns `401 Unauthorized`

## Screenshots (if UI change)

N/A (Backend/API/Security change only)

## Related issue

Closes #542

---

## Pre-Submission Checklist

* [x] Branch named following GSSoC convention: `fix/trip-routes-rate-limit-auth`
* [x] Changes committed with meaningful commit message
* [x] Changes pushed to remote fork
* [x] Relevant tests executed successfully
* [x] Code follows project contribution guidelines
