### PR TITLE
docs: link ARCHITECTURE.md in root README navigation, architecture flow, and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## ⚡ Quick Navigation
 
-| [📖 About](#-about-tourease) | [✨ Features](#-features) | [🛠️ Tech Stack](#️-tech-stack) | [🗂️ Structure](#️-project-structure) | [🏛️ Architecture](#️-architecture-flow) | [🗺️ Routes](#️-application-routes) | [🚀 Quick Start](#-quick-start) | [🤝 Contributing](CONTRIBUTING.md) |
+| [📖 About](#-about-tourease) | [✨ Features](#-features) | [🛠️ Tech Stack](#️-tech-stack) | [🗂️ Structure](#️-project-structure) | [🏛️ Architecture](docs/ARCHITECTURE.md) | [🗺️ Routes](#️-application-routes) | [🚀 Quick Start](#-quick-start) | [🤝 Contributing](CONTRIBUTING.md) |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 
 ---
@@ -157,6 +157,8 @@ TourEase/
 
 ## 🏛️ Architecture Flow
 
+> 💡 **Detailed Architecture Guide**: Visit [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for a comprehensive breakdown of the application layers, data flow diagrams, and orientation checklist.
+
 ```
 ┌──────────────────────────────────────┐
 │     Browser  (React + Vite :5173)    │
@@ -188,6 +190,9 @@ TourEase/
 | Favourites | `FavoritesContext` (React Context API) |
 | Dark / light theme | `ThemeContext` (React Context API) |
 | Server data | Local `useState` + service call |
+
+> [!NOTE]
+> For a comprehensive breakdown of the application layers, system flow diagrams, and key files, check out the full [Architecture Documentation](docs/ARCHITECTURE.md).
 
 ---
 
@@ -279,6 +284,9 @@ docker compose up --build
 ## 🚀 GSSoC 2026 Contributor Onboarding
 
 Welcome to TourEase! If you are contributing under GSSoC 2026, follow these steps to get started:
+
+> [!TIP]
+> To understand the folder layout, data flows, and layer structure of TourEase before coding, read the [Architecture Documentation](docs/ARCHITECTURE.md) first.
 
 ### Prerequisites
 - Install Git


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #620 

## Rationale for this change

Although the repository has a comprehensive system design and layering document located at `docs/ARCHITECTURE.md`, it was not linked anywhere in the main root `README.md` navigation or documentation blocks. Contributors had to manually discover it in the `docs` folder. This PR links it in key onboarding areas so new developers can find it immediately.

## What changes are included in this PR?

- **Navigation Link**: Updated `[🏛️ Architecture]` in the Quick Navigation table to point directly to `docs/ARCHITECTURE.md`.
- **Architecture Flow Link**: Added a direct callout under the `## 🏛️ Architecture Flow` heading instructing contributors to visit `docs/ARCHITECTURE.md` for the full layer breakdown.
- **Onboarding Callout**: Integrated a tooltip inside the `GSSoC 2026 Contributor Onboarding` guidelines encouraging contributors to review the architectural layouts before starting.

## UI Changes (Screenshots / Screen Recordings)

*N/A (This is a documentation configuration change)*

## Testing & Verification

- Verified relative path resolution of all new links.
- Verified staging status of the modified `README.md` file locally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or console errors
- [x] I have verified that both the frontend and backend run successfully locally
